### PR TITLE
サイズが0のファイルを同期しない

### DIFF
--- a/main.js
+++ b/main.js
@@ -245,6 +245,9 @@ exports.syncSftpDir = function(sftp, sftpDir, s3Location, fileRetentionDays, top
               return sftp.unlinkAsync(sftpDir + '/' + fileInfo.filename);
             }
           } else {
+            if (fileInfo.attrs.size <= 0) {
+              return false;
+            }
             return sftpHelper.processFile(sftp, sftpDir, fileInfo.filename, function(body) {
               var s3Path = exports.getFilePathArray(s3Location),
                   sftpPath = exports.getFilePathArray(sftpDir),


### PR DESCRIPTION
# 概要
- SFTPサーバー上にサイズが0のファイルがあると同期が失敗するのを修正

# 受入基準
- [ ] SFTPサーバー上のサイズが0のファイルが同期されない
- [ ] サイズが0より大きいファイルが正常にS3バケットに取り込まれる